### PR TITLE
Issue #2 ion channel conversion - IJ

### DIFF
--- a/examples/Wilmes_2016/biophys/jaxley/it2.py
+++ b/examples/Wilmes_2016/biophys/jaxley/it2.py
@@ -78,6 +78,7 @@ class it2(Channel):
         
     
     def compute_kinetic_variables(self, v):
+        v = v + self.channel_params.get("vshift_it2", 0)
         v12m = self.channel_params.get("v12m_it2", 1)
         v12h = self.channel_params.get("v12h_it2", 1)
         vwm = self.channel_params.get("vwm_it2", 1)

--- a/examples/Wilmes_2016/biophys/jaxley/na3dend.py
+++ b/examples/Wilmes_2016/biophys/jaxley/na3dend.py
@@ -124,6 +124,7 @@ class na3dend(Channel):
         return trap0
     
     def compute_kinetic_variables(self, v):
+        v = v + self.channel_params.get("vshift_na3dend", 0)
         tha = self.channel_params.get("tha_na3dend", 1)
         qa = self.channel_params.get("qa_na3dend", 1)
         Ra = self.channel_params.get("Ra_na3dend", 1)

--- a/examples/Wilmes_2016/biophys/jaxley/na3shifted.py
+++ b/examples/Wilmes_2016/biophys/jaxley/na3shifted.py
@@ -124,6 +124,7 @@ class na3shifted(Channel):
         return trap0
     
     def compute_kinetic_variables(self, v):
+        v = v + self.channel_params.get("vshift_na3shifted", 0)
         tha = self.channel_params.get("tha_na3shifted", 1)
         qa = self.channel_params.get("qa_na3shifted", 1)
         Ra = self.channel_params.get("Ra_na3shifted", 1)

--- a/examples/Wilmes_2016/biophys/jaxley/sca.py
+++ b/examples/Wilmes_2016/biophys/jaxley/sca.py
@@ -70,6 +70,7 @@ class sca(Channel):
         
     
     def compute_kinetic_variables(self, v):
+        v = v + self.channel_params.get("vshift_sca", 0)
         actF = self.channel_params.get("actF_sca", 1)
         inactF = self.channel_params.get("inactF_sca", 1)
         q10 = self.channel_params.get("q10_sca", 1)

--- a/src/dendrotweaks/biophys/io/code_generators.py
+++ b/src/dendrotweaks/biophys/io/code_generators.py
@@ -253,6 +253,16 @@ class PythonCodeGenerator(CodeGenerator):
             params = [param['name'] for param in procedure.signature.get('params', [])]
             if params == []:
                 params = [ast.independent_var_name]
+
+            # If vshift is a channel parameter and the independent variable is voltage,
+            # pass v + vshift to the kinetics procedure instead of bare v
+            if 'vshift' in ast.params and ast.independent_var_name == 'v':
+                params = [
+                    f'v + self.channel_params.get("vshift_{ast.suffix}", 0)'
+                    if p == 'v' else p
+                    for p in params
+                ]
+
             state_vars = list(ast.state_vars.keys())
 
             procedure_call_template = """{%- for state_var in state_vars -%}


### PR DESCRIPTION
Fixed vshift bug in Wilmes_2016 jaxley ion channels.

Made a change to PythonCodeGenerator to handle vshift in future .mod MODFileConverter conversions.

Below is claude-generated PR Summary:

 ---                                                                                                                                                                                               
  Fix: vshift voltage offset not applied in generated Jaxley channel classes
                                                                                                                                                                                                    
  Bug                                                       

  PythonCodeGenerator._generate_procedure_calls in code_generators.py always passed bare v to the channel's kinetic variables procedure, ignoring any voltage offset. MOD files that call
  rates(v+vshift) had their vshift parameter stored in channel_params but silently unused — the shift was never applied to the membrane potential before computing gate kinetics.

  This affects any channel whose PROCEDURE is called with a shifted argument (e.g. rates(v+vshift)). In the Wilmes 2016 example this was functionally significant:
  - na3dend: vshift = -5 mV (dendritic Na, hyperpolarising shift)
  - na3shifted: vshift = +10 mV (AIS Na, depolarising shift for axon initial segment excitability)

  Root cause

  _generate_procedure_calls used only the procedure signature parameter name (v from PROCEDURE rates(v(mV))), discarding the call-site expression (v+vshift) that appears in the DERIVATIVE block.

  Fix

  src/dendrotweaks/biophys/io/code_generators.py — When vshift is present in the channel's parameter dict and the independent variable is voltage, substitute the call argument with v +
  self.channel_params.get("vshift_{suffix}", 0) instead of bare v. Channels without vshift are unaffected (verified against Park 2019 — zero channels use vshift there).

  examples/Wilmes_2016/biophys/jaxley/ — Patched the 4 already-generated files (na3dend.py, na3shifted.py, sca.py, it2.py) with v = v + self.channel_params.get("vshift_{name}", 0) at the top of
  compute_kinetic_variables, bringing them in sync with what the fixed generator now produces.